### PR TITLE
Upgrade PostgreSQL from 9.6.1 to 9.6.8

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -12,20 +12,20 @@ tar/libarchive-3.1.2.tar.gz:
   sha: 6a991777ecb0f890be931cec4aec856d1a195489
 target/cfssl_linux-amd64:
   size: 10376657
-  sha: sha256:eb34ab2179e0b67c29fd55f52422a94fe751527b06a403a79325fed7cf0145bd
   object_id: 5e9d9071-4fe4-49b4-58e9-c01a06f8f945
+  sha: sha256:eb34ab2179e0b67c29fd55f52422a94fe751527b06a403a79325fed7cf0145bd
 target/cfssljson_linux-amd64:
   size: 2277873
-  sha: sha256:1c9e628c3b86c3f2f8af56415d474c9ed4c8f9246630bd21c3418dbe5bf6401e
   object_id: 898a261c-c5a0-4a11-5112-f3f1d6031dd4
+  sha: sha256:1c9e628c3b86c3f2f8af56415d474c9ed4c8f9246630bd21c3418dbe5bf6401e
 target/consul_0.7.3_linux_amd64.zip:
   size: 8728187
   object_id: 7d915fa0-64e6-47d5-bd82-bdc0951181ce
   sha: 193527eb29014201d9d242b4e2cefb3a4817f7e4
 target/etcd-v3.3.13-linux-amd64.tar.gz:
   size: 10423953
-  sha: sha256:2c2e2a9867c1c61697ea0d8c0f74c7e9f1b1cf53b75dff95ca3bc03feb19ea7e
   object_id: 1b942c00-05d9-4652-5b34-8627aa2dd7d3
+  sha: sha256:2c2e2a9867c1c61697ea0d8c0f74c7e9f1b1cf53b75dff95ca3bc03feb19ea7e
 target/mariadb-10.1.21-linux-x86_64.tar.gz:
   size: 169769845
   object_id: 780c51fe-e0be-428b-aa0a-40958d232381
@@ -38,10 +38,14 @@ target/postgresql-9.6.1.tar.bz2:
   size: 19260568
   object_id: 1e4aa257-e941-4c10-ba25-0b4b46f9142a
   sha: 4209970c9aaf91ebb2a3b8a2e359419e5192b4ad
+target/postgresql-9.6.8.tar.bz2:
+  size: 19528927
+  object_id: d1109a9e-80b4-43e0-4179-70bf4f651644
+  sha: sha256:eafdb3b912e9ec34bdd28b651d00226a6253ba65036cb9a41cad2d9e82e3eb70
 target/spruce-linux-amd64:
   size: 18471394
-  sha: sha256:414cb655257526134b61532878518b8a0ff30ab2acc172aaf1e4dd0d98068915
   object_id: d86f2a82-4f1d-47f2-65cb-a94c19022489
+  sha: sha256:414cb655257526134b61532878518b8a0ff30ab2acc172aaf1e4dd0d98068915
 vault/vault_0.9.0_linux_amd64.zip:
   size: 17571361
   object_id: 3761d729-c3cd-404f-76d8-e25dbe6f537b

--- a/packages/postgres/packaging
+++ b/packages/postgres/packaging
@@ -8,8 +8,8 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 
-tar -xjf target/postgresql-9.6.1.tar.bz2
-cd postgresql-9.6.1
+tar -xjf target/postgresql-9.6.8.tar.bz2
+cd postgresql-9.6.8
 ./configure --prefix $BOSH_INSTALL_TARGET
 make -j${CPUS}
 make install

--- a/packages/postgres/spec
+++ b/packages/postgres/spec
@@ -3,4 +3,4 @@ name: postgres
 dependencies: []
 files:
   # https://ftp.postgresql.org/pub/source/v9.6.1/postgresql-9.6.1.tar.bz2
-  - target/postgresql-9.6.1.tar.bz2
+  - target/postgresql-9.6.8.tar.bz2


### PR DESCRIPTION
### Summary of Changes:
- **Update** `blobs.yml` to include the new PostgreSQL 9.6.8 tarball with correct size, `object_id`, and SHA.
- **Modify** the packaging script to extract and build PostgreSQL 9.6.8 instead of 9.6.1.
- **Update** the package specification to reference the new tarball.

---

### Motivation:
This version includes the following key fix:
- Renamed the `pg_rewind` function `copy_file_range` to avoid a conflict with the Linux system call of the same name, introduced in newer kernel versions.

---

### Issue Addressed:
This change resolves the following error during the pipeline task:
```
Error: Action Failed get_task: Task 48ae8177-8df1-4a75-6579-e22a05b1790a result: Compiling package postgres: Running packaging script: Command exited with 2;
copy_fetch.c:161:1: error: conflicting types for 'copy_file_range'; have 'void(const char *, off_t, off_t, bool)' ...
```
