### PR TITLE
Fix: Ensure proper ownership and perms for certs

### DIFF
--- a/jobs/targets/templates/bin/consul
+++ b/jobs/targets/templates/bin/consul
@@ -15,6 +15,11 @@ case $1 in
             openssl rsa  -noout -in ${JOB_DIR}/tls/peer/key.pem); then
       mkdir -p ${JOB_DIR}/tls/peer
       /var/vcap/packages/certifier/bin/certify ${JOB_DIR}/tls/peer/
+    # Ensure ownership and permissions are correct after certificate generation
+      echo "[$(date)] Adjusting ownership and permissions for ${JOB_DIR}/tls/peer..."
+      chown -R vcap:vcap ${JOB_DIR}/tls/peer
+      chmod 640 ${JOB_DIR}/tls/peer/key.pem
+      chmod 644 ${JOB_DIR}/tls/peer/ca.pem ${JOB_DIR}/tls/peer/cert.pem
     fi
 
     echo "[$(date)] $TARGET phalanx target exec'ing..."


### PR DESCRIPTION
- Added a step to adjust ownership and permissions after certificate generation in the consul startup script.
- Ensures that certificates in `${JOB_DIR}/tls/peer/` are owned by `vcap:vcap`.
- Sets appropriate permissions:
  - `key.pem`: 640 (read/write for owner, read for group)
  - `ca.pem` and `cert.pem`: 644 (read for everyone, write for owner only)
- Added log messages to indicate when ownership and permissions are being adjusted.

This prevents 'permission denied' errors during Consul startup due to insufficient access to the key and cert files.