### PR TITLE
Add detailed debug output to `deleteVals` function

### DIFF
--- a/jobs/tests/templates/tests/etcd
+++ b/jobs/tests/templates/tests/etcd
@@ -81,8 +81,18 @@ dumpKeys() {
 deleteVals() {
     local url=$1
     local authOption=$2
-    echo "Deleting keys and values"
-    etcdctl $authOption --endpoints=$url del "" --prefix=true
+    echo "Deleting keys and values on endpoint: $url with options: $authOption"
+
+    echo "Testing connection to endpoint before delete operation..."
+    etcdctl $authOption --endpoints=$url endpoint status || echo "Failed to connect to endpoint" 
+
+    echo "Attempting to delete keys with etcdctl command..."
+    etcdctl $authOption --endpoints=$url del "" --prefix=true || echo "Delete operation failed"
+
+    echo "Checking remaining keys after failed delete attempt..."
+    etcdctl $authOption --endpoints=$url get "" --prefix=true || echo "Failed to retrieve keys after delete attempt"
+
+    echo "Finished delete operation debug."
     echo
 }
 


### PR DESCRIPTION
- Added debug logging to provide more information during the `deleteVals` operation.
- Included a connection test (`etcdctl endpoint status`) to check endpoint availability before attempting to delete keys.
- Added error handling for delete command failure and a post-failure key dump (`etcdctl get`).
- Improved troubleshooting capability by logging endpoint, authentication options, and command results.