### PR TITLE
Add SAN support to etcd certificate generation

### DIFF
--- a/jobs/tests/templates/bin/pre-start
+++ b/jobs/tests/templates/bin/pre-start
@@ -8,7 +8,10 @@ JOB_DIR=/var/vcap/jobs/tests/data/$JOB
 CERTS_DIR=/var/vcap/data/targets
 TMP_DIR=/var/vcap/data/tmp/$JOB
 
-# put cfssl in our path
+# Export TARGET for SAN generation
+export TARGET="<%= link('shield').instances[0].address %>"
+
+# Add cfssl to PATH
 export PATH=$PATH:/var/vcap/packages/cfssl/bin
 
 echo "[$(date)] $BIN/$$: regenerating certificates..."
@@ -69,7 +72,7 @@ EOF
 
 echo "[$(date)] $BIN/$$: issuing the etcd server certificate for etcd"
 gencert etcd \
-        127.0.0.1,<%= spec.ip %> \
+        "127.0.0.1,<%= spec.ip %>,$TARGET" \
         etcd
 
 popd >/dev/null 2>&1


### PR DESCRIPTION
- Exported TARGET using `<%= link('shield').instances[0].address %>` for dynamic hostname inclusion.
- Modified `gencert` function to add `TARGET` as a Subject Alternative Name (SAN).
- Ensured that the generated etcd certificate includes both the IP address and the specified hostname.
- This change resolves SSL verification issues caused by missing SAN entries.