### PR TITLE
Add SAN support to etcd server certificate

### DIFF
--- a/jobs/targets/templates/bin/pre-start
+++ b/jobs/targets/templates/bin/pre-start
@@ -8,7 +8,10 @@ JOB_DIR=/var/vcap/jobs/targets/config/$JOB
 CERTS_DIR=/var/vcap/data/targets
 TMP_DIR=/var/vcap/data/etcd/tmp/$JOB
 
-# put cfssl in our path
+# Export TARGET for SAN generation
+export TARGET="<%= link('shield').instances[0].address %>"
+
+# Add cfssl to PATH
 export PATH=$PATH:/var/vcap/packages/cfssl/bin
 
 echo "[$(date)] $BIN/$$: regenerating certificates..."
@@ -69,7 +72,7 @@ EOF
 
 echo "[$(date)] $BIN/$$: issuing the etcd server certificate for etcd"
 gencert etcd \
-        127.0.0.1,<%= spec.ip %> \
+        "127.0.0.1,<%= spec.ip %>,$TARGET" \
         etcd
 
 popd >/dev/null 2>&1


### PR DESCRIPTION
- Exported `TARGET` using `<%= link('shield').instances[0].address %>` to dynamically include the BOSH DNS name.
- Updated the `gencert` function in `jobs/targets/templates/bin/pre-start` to add `TARGET` to the Subject Alternative Name (SAN).
- Ensured that the certificate generated for the etcd server includes both IP addresses (`127.0.0.1`, the server's local IP) and the BOSH DNS name.
- This change resolves SSL handshake failures caused by missing SAN entries when accessing etcd using the DNS hostname.

This commit complements the previous change made to jobs/tests/templates/bin/pre-start, ensuring both tests and services generate SAN-compliant certificates.