### PR TITLE
Add `shield` link consumption for the targets job

### DIFF
--- a/ci/manifest.yml
+++ b/ci/manifest.yml
@@ -35,6 +35,8 @@ instance_groups:
       - { release: shield-phalanx, name: agent   }
       - name: targets
         release: shield-phalanx
+        consumes:
+          shield: {from: shield}
         properties:
           tls:
             ca:


### PR DESCRIPTION
- Updated the BOSH manifest to include a `consumes` section for the `targets` job.
- This allows the `targets` job to reference the `shield` link, enabling dynamic certificate generation with the correct SAN entry.
- The change resolves errors related to missing links during template rendering in the `pre-start` script for the `targets` job.