### PR TITLE
Provide and consume shield link in CI manifest

### DIFF
--- a/ci/manifest.yml
+++ b/ci/manifest.yml
@@ -31,12 +31,20 @@ instance_groups:
     networks:
       - name: default
     jobs:
-      - { release: shield-phalanx, name: shield  }
-      - { release: shield-phalanx, name: agent   }
+      - name: shield
+        release: shield-phalanx
+        provides:
+          shield: { shared: true, as: shield }
+
+      - name: agent
+        release: shield-phalanx
+        consumes:
+          shield: { from: shield }
+
       - name: targets
         release: shield-phalanx
         consumes:
-          shield: {from: shield}
+          shield: { from: shield }
         properties:
           tls:
             ca:
@@ -52,7 +60,7 @@ instance_groups:
     networks:
       - name: default
     jobs:
-      - name:    tests
+      - name: tests
         release: shield-phalanx
         properties:
           aws:


### PR DESCRIPTION
- Updated the `shield` job to provide the `shield` link using `provides: shield`.
- Modified the `agent` and `targets` jobs to consume the `shield` link using `consumes: shield`.
- This change resolves the "Can't find link 'shield'" error by ensuring that the required link is declared and shared correctly across jobs.
- Updated formatting in the `ci/manifest.yml` to improve readability.